### PR TITLE
Make header links clickable and remove learn tab

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -9,8 +9,10 @@ body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple
 .mast{background:var(--brand-deep);color:#fff}
 .mast .top{display:flex;align-items:center;justify-content:space-between;gap:16px;max-width:1200px;margin:0 auto;padding:12px 16px}
 .logo{display:flex;align-items:center;gap:12px}
-.nav-icons{display:flex;gap:18px}
-.mainnav{display:flex;gap:24px;max-width:1200px;margin:0 auto;padding:10px 16px;border-top:1px solid rgba(255,255,255,.15)}
+.nav-icons{display:flex;gap:18px;flex-wrap:wrap}
+.nav-icons .i{color:#dbe7ff;text-decoration:none}
+.nav-icons .i:hover{color:#ffffff}
+.mainnav{display:flex;gap:24px;max-width:1200px;margin:0 auto;padding:10px 16px;border-top:1px solid rgba(255,255,255,.15);flex-wrap:wrap}
 .mainnav a{color:#dbe7ff;text-decoration:none;font-weight:600}
 .mainnav a:hover{color:#ffffff}
 .app{max-width:1200px;margin:20px auto;padding:0 16px}
@@ -34,14 +36,8 @@ button:hover{filter:brightness(1.05)}
 .result{padding:10px;border-radius:8px;margin-top:8px;background:#f8fafc;border:1px solid var(--border)}
 .result.ok{border-color:#1d8d5d}.result.warn{border-color:var(--warn)}.result.bad{border-color:var(--bad)}
 .list{padding-left:18px}.muted{color:var(--muted)}
-.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:12px}
-.cards .a { display: none !important; }
-.cards .card.show .a { display: block !important; }
 .footer{display:flex;justify-content:space-between;align-items:center;gap:10px;padding:12px 16px;border-top:1px solid var(--border);background:#fff}
 
-.cards .a {
-  display: none !important;
-}
-.cards .card.show .a {
-  display: block !important;
+@media (max-width:600px){
+  .mast .top{flex-direction:column;align-items:flex-start}
 }

--- a/index.html
+++ b/index.html
@@ -19,10 +19,10 @@
         <strong>Zürcher Kantonalbank</strong>
       </div>
       <nav class="nav-icons">
-        <span class="i">Kontakt</span>
-        <span class="i">Hilfe</span>
-        <span class="i">Suche</span>
-        <span class="i">eBanking</span>
+        <a class="i" href="https://twinjn.netlify.app">Kontakt</a>
+        <a class="i" href="https://twinjn.netlify.app">Hilfe</a>
+        <a class="i" href="https://twinjn.netlify.app">Suche</a>
+        <a class="i" href="https://twinjn.netlify.app">eBanking</a>
       </nav>
     </div>
     <nav class="mainnav">
@@ -42,7 +42,6 @@
       <button class="tab_button" data-tab="tab_goals">Ziele</button>
       <button class="tab_button" data-tab="tab_guard">Betrugsschutz</button>
       <button class="tab_button" data-tab="tab_impact">Impact</button>
-      <button class="tab_button" data-tab="tab_learn">Lernen</button>
       <button class="tab_button" data-tab="tab_tools">Rechner</button>
       <button class="tab_button" data-tab="tab_budget">Budget</button>
     </div>
@@ -129,13 +128,6 @@
       </div>
     </section>
     
-    <!-- Removed Lernkarten section as per user request -->
-    <!--
-    <section id="tab_learn" class="tab">
-      <h1>Lernkarten</h1>
-      <div id="cards" class="cards"></div>
-    </section>
-    -->
 
     <section id="tab_tools" class="tab">
       <h1>Rechner</h1>

--- a/js/app.js
+++ b/js/app.js
@@ -10,7 +10,6 @@ $$('.tab_button').forEach(btn=>{
     const id=btn.dataset.tab; $$('.tab').forEach(t=>t.classList.remove('active'));
     document.getElementById(id).classList.add('active');
     if(id==='tab_map'){setTimeout(()=>map?.invalidateSize(),100)}
-    if(id==='tab_learn'){renderCards()}
   })
 })
 
@@ -67,41 +66,6 @@ const co2Factors={kaffee:0.4,oepnv:0.05,elektronik:1.2,essen:0.3};
 $('#co2_add').addEventListener('click',()=>{const k=$('#co2_cat').value; const amt=Number($('#co2_amount').value||0); const list=store.get('co2',[]); const est=Number((amt*(co2Factors[k]||0.2)).toFixed(2)); list.push({k,amt,est}); store.set('co2',list); renderCO2()})
 function renderCO2(){const list=store.get('co2',[]); const ul=$('#co2_list'); ul.innerHTML=''; let sum=0; list.forEach(x=>{sum+=x.est; const li=document.createElement('li'); li.textContent=`${x.k} – Betrag ${x.amt} CHF – Schätzung ${x.est} kg CO₂`; ul.appendChild(li)}); $('#co2_sum').textContent=`Summe geschätzter CO₂ Werte: ${sum.toFixed(2)} kg`}
 
-// Lernkarten
-const learnCards=[
-  {q:'Was ist Budgetierung',a:'Plane Einnahmen und Ausgaben im Voraus. Lege Ziele fest und prüfe monatlich den Stand.'},
-  {q:'Wie wirkt Zinseszins',a:'Zinsen werden dem Kapital zugerechnet und erwirtschaften selber wieder Zinsen. Früh beginnen lohnt sich.'},
-  {q:'Was ist ein Notgroschen',a:'Ein Geldpolster für unerwartete Ausgaben. Drei Monatsausgaben sind ein guter Richtwert.'},
-  {q:'Sichere Karte online',a:'Nutze 3D Secure, gib Daten nur auf vertrauenswürdigen Seiten ein und prüfe die Adresse sorgfältig.'}
-];
-function renderCards(){
-  const wrap=$('#cards');
-  console.log('Rendering cards...');
-  wrap.innerHTML='';
-  learnCards.forEach((c,i)=>{
-    const d=document.createElement('div');
-    d.className='card';
-    d.innerHTML=`<div class="q">${c.q}</div><div class="a">${c.a}</div><button data-i="${i}" class="reveal">zeigen</button>`;
-    wrap.appendChild(d);
-    const answer = d.querySelector('.a');
-    if(answer) answer.style.display = 'none';
-  });
-  console.log('Cards rendered:', wrap.children.length);
-  $$('.reveal').forEach(btn=>btn.addEventListener('click',e=>{
-    console.log('zeigen button clicked for card', e.target.dataset.i, 'target:', e.target);
-    const i=Number(e.target.dataset.i);
-    const card=$$('.card')[i];
-    card.classList.toggle('show');
-    const answer = card.querySelector('.a');
-    if(card.classList.contains('show')){
-      answer.style.display = 'block';
-    } else {
-      answer.style.display = 'none';
-    }
-    e.target.textContent=card.classList.contains('show')?'verbergen':'zeigen';
-  }));
-}
-
 // Tools
 const RATES={CHF:1, EUR:0.98, USD:1.1, GBP:0.85};
 $('#fx_convert').addEventListener('click',()=>{
@@ -143,10 +107,10 @@ $('#bdg_spent_add').addEventListener('click',()=>{
 })
 
 // Reset
-$('#btn_reset').addEventListener('click',()=>{if(confirm('Alle Demo Daten löschen')){localStorage.clear(); renderGoals(); updateImpactChart(); renderCO2(); renderCards(); renderBudget()}})
+$('#btn_reset').addEventListener('click',()=>{if(confirm('Alle Demo Daten löschen')){localStorage.clear(); renderGoals(); updateImpactChart(); renderCO2(); renderBudget()}})
 
 // Init
 window.addEventListener('DOMContentLoaded',()=>{
   if(!store.get('goals',null)) store.set('goals',[{name:'Notebook',target:1200,saved:120},{name:'Notgroschen',target:900,saved:60}]);
-  renderGoals(); renderCO2(); renderCards(); renderBudget(); updateImpactChart(); initMap();
+  renderGoals(); renderCO2(); renderBudget(); updateImpactChart(); initMap();
 })


### PR DESCRIPTION
## Summary
- Link Kontakt, Hilfe, Suche und eBanking to twinjn.netlify.app via clickable header icons.
- Remove unused "Lernen" tab and supporting JavaScript.
- Add basic responsive styling so header and navigation wrap on small screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09147ee5c8330917b0812ebe58bab