### PR TITLE
Improve mobile layout and map handling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,4 +40,11 @@ button:hover{filter:brightness(1.05)}
 
 @media (max-width:600px){
   .mast .top{flex-direction:column;align-items:flex-start}
+  .mainnav{flex-direction:column;gap:12px}
+  .tabs{overflow-x:auto}
+  .actions{flex-direction:column}
+  .inline{flex-direction:column;align-items:stretch}
+  .hero{height:120px}
+  .map{height:260px}
+  .footer{flex-direction:column;align-items:flex-start}
 }

--- a/js/app.js
+++ b/js/app.js
@@ -112,5 +112,6 @@ $('#btn_reset').addEventListener('click',()=>{if(confirm('Alle Demo Daten lösch
 // Init
 window.addEventListener('DOMContentLoaded',()=>{
   if(!store.get('goals',null)) store.set('goals',[{name:'Notebook',target:1200,saved:120},{name:'Notgroschen',target:900,saved:60}]);
-  renderGoals(); renderCO2(); renderBudget(); updateImpactChart(); initMap();
+  renderGoals(); renderCO2(); renderBudget(); updateImpactChart();
+  if(window.L && document.getElementById('map')){initMap()}else{const el=document.getElementById('map'); if(el){const p=document.createElement('p'); p.className='muted'; p.textContent='Karte konnte nicht geladen werden.'; el.replaceWith(p)}}
 })


### PR DESCRIPTION
## Summary
- refine responsive layout with additional media queries for navigation, actions and map
- guard map initialization so a clear message shows if Leaflet fails to load

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c116ba3ac48330ab05016920421e90