### PR TITLE
Show fallback when map tiles fail

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -22,7 +22,8 @@ body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple
 .tab{display:none}.tab.active{display:block}
 .actions{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
 .hero{width:100%;height:160px;object-fit:cover;border-radius:10px;border:1px solid var(--border);margin-bottom:10px}
-.map{height:380px;width:100%;border-radius:10px;overflow:hidden;border:1px solid var(--border)}
+.map{height:380px;width:100%;border-radius:10px;overflow:hidden;border:1px solid var(--border);position:relative}
+.map_notice{position:absolute;top:8px;left:8px;background:#fff;padding:4px 6px;border:1px solid var(--border);border-radius:4px;font-size:12px;color:var(--muted)}
 .card{background:var(--card);border:1px solid var(--border);padding:14px;border-radius:12px;margin:12px 0;box-shadow:0 1px 2px rgba(20,24,31,.06),0 8px 24px rgba(20,24,31,.04)}
 .inline{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
 input,select,textarea,button{background:#ffffff;color:var(--ink);border:1px solid var(--border);padding:8px 10px;border-radius:8px}

--- a/js/app.js
+++ b/js/app.js
@@ -24,7 +24,32 @@ const PROJECTS=[
 let map; let currentProject=null;
 function initMap(){
   map=L.map('map').setView([47.3889,8.5186],13);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19,attribution:'© OpenStreetMap'}).addTo(map);
+  const tiles=L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19,attribution:'© OpenStreetMap'});
+  tiles.on('tileerror',()=>{
+    map.removeLayer(tiles);
+    const fallback=L.gridLayer();
+    fallback.createTile=function(){
+      const tile=document.createElement('canvas');
+      const size=this.getTileSize();
+      tile.width=size.x; tile.height=size.y;
+      const ctx=tile.getContext('2d');
+      ctx.fillStyle='#f1f5f9';
+      ctx.fillRect(0,0,size.x,size.y);
+      ctx.strokeStyle='#d1d5db';
+      ctx.strokeRect(0,0,size.x,size.y);
+      ctx.fillStyle='#9ca3af';
+      ctx.font='12px sans-serif';
+      ctx.fillText('offline',8,20);
+      return tile;
+    };
+    fallback.addTo(map);
+    const c=map.getContainer();
+    const info=document.createElement('div');
+    info.className='map_notice';
+    info.textContent='Kartenkacheln konnten nicht geladen werden.';
+    c.appendChild(info);
+  });
+  tiles.addTo(map);
   PROJECTS.forEach(p=>{const m=L.marker([p.lat,p.lng]).addTo(map); m.on('click',()=>showProject(p)); m.bindTooltip(p.title)})
 }
 function showProject(p){currentProject=p; $('#project_info').hidden=false; $('#project_title').textContent=p.title; $('#project_desc').textContent=p.desc}


### PR DESCRIPTION
## Summary
- Render offline-friendly grid tiles when OpenStreetMap tiles cannot load
- Display message within the map container when tile downloads fail
- Style map container for notice overlay

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c13793e024833080ea320e999e265e